### PR TITLE
Exclude test that is skipped due to missing PHP extension

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -11,6 +11,7 @@
          verbose="true">
     <testsuite name="Money">
         <directory>../tests</directory>
+        <exclude>../tests/IntlFormatterTest.php</exclude>
     </testsuite>
 
     <logging>


### PR DESCRIPTION
As this makes all new branches/pull requests fail to build the first
time, unless I increase the permitted limits to unwanted degrees